### PR TITLE
fix(grafana): fix dashboard PromQL queries, legends, and skip CI for …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,16 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [ "main", "feature/*", "develop" ]
+    paths-ignore:
+      - '**.md'
+      - '.github/workflows/**'
+      - 'resources/**'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '**.md'
+      - '.github/workflows/**'
+      - 'resources/**'
   release:
     types: [ published ]
 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,13 @@ Alternatively, point your HTTP client to `http://localhost:9000/api/prometheus/m
 - Or configure default severities under **Administration** &rarr; **Configuration** &rarr; **General Settings** &rarr; **Prometheus Exporter** &rarr; **Filter by Severity**.
 
 ### 4. Grafana Dashboard
-You can import the sample dashboard from this file:
+You can import the sample dashboard template from:
 ```bash
 resources/grafana_dashboard.json
 ```
+
+- **Dynamic Project Filtering**: The dashboard includes a `$Key` template variable populated via `label_values(sonarqube_ncloc, key)` supporting **Multi-value** and **All** project selections.
+- **PromQL Queries & Legends**: All panel queries filter using `key=~"$Key"` and format legends with `{{key}}` to clearly display project identifiers across cards and time series graphs.
 
 > **Note:** The provided `grafana_dashboard.json` is a base template intended to help you quickly get started. Depending on your Grafana configuration, version, and custom panel customizations, the visual appearance may differ from the dashboard screenshot shown below.
 

--- a/resources/grafana_dashboard.json
+++ b/resources/grafana_dashboard.json
@@ -33,7 +33,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "- Lines (lines): The number of physical lines \n- Lines of code (ncloc): The number of physical lines that contain at least one character\n- Comment lines (comment_lines): The number of lines containing comment",
+      "description": "- Lines\u00a0(lines): The number of physical lines \n- Lines of code\u00a0(ncloc): The number of physical lines that contain at least one character\n- Comment lines\u00a0(comment_lines): The number of lines containing comment",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -81,7 +81,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_ncloc{name=~\"$project_name\"}",
+          "expr": "sonarqube_ncloc{key=~\"$Key\"}",
           "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
@@ -149,7 +149,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_sqale_index{name=~\"$project_name\"}",
+          "expr": "sonarqube_sqale_index{key=~\"$Key\"}",
           "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
@@ -176,7 +176,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "The state of the quality gate associated with your project. Possible values are ERROR and OK",
+      "description": "The state of the quality gate associated with your project. Possible values are\u00a0ERROR and\u00a0OK",
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -246,7 +246,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sonarqube_alert_status{name=~\"$project_name\"}",
+          "expr": "sonarqube_alert_status{key=~\"$Key\"}",
           "format": "heatmap",
           "instant": false,
           "legendFormat": "{{name}}",
@@ -345,7 +345,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_security_hotspots{name=~\"$project_name\"}",
+          "expr": "sonarqube_security_hotspots{key=~\"$Key\"}",
           "format": "heatmap",
           "legendFormat": "{{name}}",
           "range": true,
@@ -443,7 +443,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_code_smells{name=~\"$project_name\"}",
+          "expr": "sonarqube_code_smells{key=~\"$Key\"}",
           "format": "heatmap",
           "legendFormat": "{{name}}",
           "range": true,
@@ -506,7 +506,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_vulnerabilities{name=~\"$project_name\"}",
+          "expr": "sonarqube_vulnerabilities{key=~\"$Key\"}",
           "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
@@ -581,7 +581,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_violations{name=~\"$project_name\"}",
+          "expr": "sonarqube_violations{key=~\"$Key\"}",
           "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
@@ -678,8 +678,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_open_issues{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_open_issues{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         },
@@ -689,7 +689,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_lines_to_cover{name=~\"$project_name\"}",
+          "expr": "sonarqube_lines_to_cover{key=~\"$Key\"}",
           "hide": false,
           "legendFormat": "{{name}}",
           "range": true,
@@ -701,9 +701,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_confirmed_issues{name=~\"$project_name\"}",
+          "expr": "sonarqube_confirmed_issues{key=~\"$Key\"}",
           "hide": false,
-          "legendFormat": "{{__name__}}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "C"
         },
@@ -713,9 +713,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_false_positive_issues{name=~\"$project_name\"} ",
+          "expr": "sonarqube_false_positive_issues{key=~\"$Key\"} ",
           "hide": false,
-          "legendFormat": "{{__name__}}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "D"
         },
@@ -725,9 +725,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_violations{name=~\"$project_name\"}",
+          "expr": "sonarqube_violations{key=~\"$Key\"}",
           "hide": false,
-          "legendFormat": "{{__name__}}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "E"
         }
@@ -805,8 +805,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_vulnerabilities{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_vulnerabilities{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -871,8 +871,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_security_remediation_effort{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_security_remediation_effort{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -885,7 +885,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "The number of Security Hotspots",
+      "description": "The\u00a0number of Security Hotspots",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -937,13 +937,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_security_hotspots_reviewed_status{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_security_hotspots_reviewed_status{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "The number of Security Hotspots",
+      "title": "The\u00a0number of Security Hotspots",
       "type": "stat"
     },
     {
@@ -951,7 +951,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Security Rating (security_rating)\n- A = 0 Vulnerabilities\n- B = at least 1 Minor Vulnerability\n- C = at least 1 Major Vulnerability\n- D = at least 1 Critical Vulnerability\n- E = at least 1 Blocker Vulnerability",
+      "description": "Security Rating\u00a0(security_rating)\n- A = 0 Vulnerabilities\n- B = at least 1 Minor Vulnerability\n- C = at least 1 Major Vulnerability\n- D = at least 1 Critical Vulnerability\n- E = at least 1 Blocker Vulnerability",
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -1030,8 +1030,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_security_rating{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_security_rating{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1127,8 +1127,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_security_review_rating{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_security_review_rating{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1154,7 +1154,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "- Duplicated blocks (duplicated_blocks): The number of duplicated blocks of lines.\n- Duplicated lines (duplicated_lines): The number of lines involved in duplications.\n- Duplicated files (duplicated_files): The number of files involved in duplications.",
+      "description": "- Duplicated blocks\u00a0(duplicated_blocks): The number of duplicated blocks of lines.\n- Duplicated lines\u00a0(duplicated_lines): The number of lines involved in duplications.\n- Duplicated files\u00a0(duplicated_files): The number of files involved in duplications.",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -1206,8 +1206,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_duplicated_lines{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_duplicated_lines{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         },
@@ -1217,9 +1217,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_duplicated_files{name=~\"$project_name\"} ",
+          "expr": "sonarqube_duplicated_files{key=~\"$Key\"} ",
           "hide": false,
-          "legendFormat": "{{__name__}}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "B"
         },
@@ -1229,9 +1229,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_duplicated_blocks{name=~\"$project_name\"}",
+          "expr": "sonarqube_duplicated_blocks{key=~\"$Key\"}",
           "hide": false,
-          "legendFormat": "{{__name__}}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "C"
         }
@@ -1244,7 +1244,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Duplicated lines (%) (duplicated_lines_density): duplicated_lines / (lines of code) * 100",
+      "description": "Duplicated lines (%)\u00a0(duplicated_lines_density):\u00a0duplicated_lines\u00a0/\u00a0(lines of code) * 100",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -1298,8 +1298,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_duplicated_lines_density{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_duplicated_lines_density{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1378,8 +1378,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_coverage{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_coverage{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1440,8 +1440,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_lines_to_cover{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_lines_to_cover{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1502,8 +1502,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_tests{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_tests{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1577,7 +1577,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_violations{name=~\"$project_name\"}",
+          "expr": "sonarqube_violations{key=~\"$Key\"}",
           "hide": false,
           "legendFormat": "{{rule}}",
           "range": true,
@@ -1660,8 +1660,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_bugs{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_bugs{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1754,8 +1754,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_reliability_rating{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_reliability_rating{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1813,8 +1813,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_reliability_remediation_effort{name=~\"$project_name\"}",
-          "legendFormat": "__auto",
+          "expr": "sonarqube_reliability_remediation_effort{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1885,8 +1885,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_code_smells{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_code_smells{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2002,8 +2002,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_sqale_rating{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_sqale_rating{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2061,8 +2061,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_sqale_index{name=~\"$project_name\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_sqale_index{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2137,8 +2137,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_complexity{name=~\"$project_name\"}",
-          "legendFormat": "{{project_name}}",
+          "expr": "sonarqube_complexity{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2196,8 +2196,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_cognitive_complexity{name=~\"$project_name\"}",
-          "legendFormat": "{{project_name}}",
+          "expr": "sonarqube_cognitive_complexity{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2255,8 +2255,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_complexity{name=~\"$project_name\"}",
-          "legendFormat": "{{project_name}}",
+          "expr": "sonarqube_complexity{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2344,8 +2344,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_exporter_up{name=~\"$project_name\"}",
-          "legendFormat": "__auto",
+          "expr": "sonarqube_exporter_up{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2360,7 +2360,7 @@
               "event_id",
               "job",
               "project_version",
-              "project_name"
+              "key"
             ],
             "mode": "columns",
             "valueLabel": "__name__"
@@ -2385,18 +2385,18 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "sonarqube_bugs",
+        "definition": "label_values(sonarqube_ncloc, key)",
         "includeAll": true,
-        "label": "Project Name",
+        "label": "Key",
         "multi": true,
-        "name": "project_name",
+        "name": "Key",
         "options": [],
         "query": {
-          "query": "sonarqube_bugs",
+          "query": "label_values(sonarqube_ncloc, key)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": ".*name=\"([^\"]*).*",
+        "regex": "",
         "type": "query"
       }
     ]

--- a/resources/resources-v1.0.0/grafana_dashboard.json
+++ b/resources/resources-v1.0.0/grafana_dashboard.json
@@ -33,7 +33,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "- Lines (lines): The number of physical lines \n- Lines of code (ncloc): The number of physical lines that contain at least one character\n- Comment lines (comment_lines): The number of lines containing comment",
+      "description": "- Lines\u00a0(lines): The number of physical lines \n- Lines of code\u00a0(ncloc): The number of physical lines that contain at least one character\n- Comment lines\u00a0(comment_lines): The number of lines containing comment",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -81,7 +81,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_ncloc{key=~\"$project_key\"}",
+          "expr": "sonarqube_ncloc{key=~\"$Key\"}",
           "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
@@ -149,7 +149,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_sqale_index{key=~\"$project_key\"}",
+          "expr": "sonarqube_sqale_index{key=~\"$Key\"}",
           "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
@@ -176,7 +176,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "The state of the quality gate associated with your project. Possible values are ERROR and OK",
+      "description": "The state of the quality gate associated with your project. Possible values are\u00a0ERROR and\u00a0OK",
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -246,7 +246,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sonarqube_alert_status{key=~\"$project_key\"}",
+          "expr": "sonarqube_alert_status{key=~\"$Key\"}",
           "format": "heatmap",
           "instant": false,
           "legendFormat": "{{key}}",
@@ -345,7 +345,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_security_hotspots{key=~\"$project_key\"}",
+          "expr": "sonarqube_security_hotspots{key=~\"$Key\"}",
           "format": "heatmap",
           "legendFormat": "{{key}}",
           "range": true,
@@ -443,7 +443,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_code_smells{key=~\"$project_key\"}",
+          "expr": "sonarqube_code_smells{key=~\"$Key\"}",
           "format": "heatmap",
           "legendFormat": "{{key}}",
           "range": true,
@@ -506,7 +506,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_vulnerabilities{key=~\"$project_key\"}",
+          "expr": "sonarqube_vulnerabilities{key=~\"$Key\"}",
           "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
@@ -581,7 +581,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_violations{key=~\"$project_key\"}",
+          "expr": "sonarqube_violations{key=~\"$Key\"}",
           "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
@@ -678,8 +678,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_open_issues{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_open_issues{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         },
@@ -689,7 +689,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_lines_to_cover{key=~\"$project_key\"}",
+          "expr": "sonarqube_lines_to_cover{key=~\"$Key\"}",
           "hide": false,
           "legendFormat": "{{key}}",
           "range": true,
@@ -701,9 +701,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_confirmed_issues{key=~\"$project_key\"}",
+          "expr": "sonarqube_confirmed_issues{key=~\"$Key\"}",
           "hide": false,
-          "legendFormat": "{{__name__}}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "C"
         },
@@ -713,9 +713,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_false_positive_issues{key=~\"$project_key\"} ",
+          "expr": "sonarqube_false_positive_issues{key=~\"$Key\"} ",
           "hide": false,
-          "legendFormat": "{{__name__}}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "D"
         },
@@ -725,9 +725,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_violations{key=~\"$project_key\"}",
+          "expr": "sonarqube_violations{key=~\"$Key\"}",
           "hide": false,
-          "legendFormat": "{{__name__}}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "E"
         }
@@ -805,8 +805,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_vulnerabilities{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_vulnerabilities{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -871,8 +871,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_security_remediation_effort{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_security_remediation_effort{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -885,7 +885,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "The number of Security Hotspots",
+      "description": "The\u00a0number of Security Hotspots",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -937,13 +937,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_security_hotspots_reviewed_status{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_security_hotspots_reviewed_status{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "The number of Security Hotspots",
+      "title": "The\u00a0number of Security Hotspots",
       "type": "stat"
     },
     {
@@ -951,7 +951,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Security Rating (security_rating)\n- A = 0 Vulnerabilities\n- B = at least 1 Minor Vulnerability\n- C = at least 1 Major Vulnerability\n- D = at least 1 Critical Vulnerability\n- E = at least 1 Blocker Vulnerability",
+      "description": "Security Rating\u00a0(security_rating)\n- A = 0 Vulnerabilities\n- B = at least 1 Minor Vulnerability\n- C = at least 1 Major Vulnerability\n- D = at least 1 Critical Vulnerability\n- E = at least 1 Blocker Vulnerability",
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -1030,8 +1030,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_security_rating{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_security_rating{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1127,8 +1127,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_security_review_rating{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_security_review_rating{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1154,7 +1154,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "- Duplicated blocks (duplicated_blocks): The number of duplicated blocks of lines.\n- Duplicated lines (duplicated_lines): The number of lines involved in duplications.\n- Duplicated files (duplicated_files): The number of files involved in duplications.",
+      "description": "- Duplicated blocks\u00a0(duplicated_blocks): The number of duplicated blocks of lines.\n- Duplicated lines\u00a0(duplicated_lines): The number of lines involved in duplications.\n- Duplicated files\u00a0(duplicated_files): The number of files involved in duplications.",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -1206,8 +1206,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_duplicated_lines{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_duplicated_lines{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         },
@@ -1217,9 +1217,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_duplicated_files{key=~\"$project_key\"} ",
+          "expr": "sonarqube_duplicated_files{key=~\"$Key\"} ",
           "hide": false,
-          "legendFormat": "{{__name__}}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "B"
         },
@@ -1229,9 +1229,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_duplicated_blocks{key=~\"$project_key\"}",
+          "expr": "sonarqube_duplicated_blocks{key=~\"$Key\"}",
           "hide": false,
-          "legendFormat": "{{__name__}}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "C"
         }
@@ -1244,7 +1244,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Duplicated lines (%) (duplicated_lines_density): duplicated_lines / (lines of code) * 100",
+      "description": "Duplicated lines (%)\u00a0(duplicated_lines_density):\u00a0duplicated_lines\u00a0/\u00a0(lines of code) * 100",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -1298,8 +1298,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_duplicated_lines_density{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_duplicated_lines_density{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1378,8 +1378,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_coverage{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_coverage{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1440,8 +1440,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_lines_to_cover{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_lines_to_cover{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1502,8 +1502,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_tests{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_tests{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1577,7 +1577,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_violations{key=~\"$project_key\"}",
+          "expr": "sonarqube_violations{key=~\"$Key\"}",
           "hide": false,
           "legendFormat": "{{rule}}",
           "range": true,
@@ -1660,8 +1660,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_bugs{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_bugs{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1754,8 +1754,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_reliability_rating{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_reliability_rating{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1813,8 +1813,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_reliability_remediation_effort{key=~\"$project_key\"}",
-          "legendFormat": "__auto",
+          "expr": "sonarqube_reliability_remediation_effort{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -1885,8 +1885,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_code_smells{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_code_smells{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2002,8 +2002,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_sqale_rating{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_sqale_rating{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2061,8 +2061,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_sqale_index{key=~\"$project_key\"}",
-          "legendFormat": "{{__name__}}",
+          "expr": "sonarqube_sqale_index{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2137,8 +2137,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_complexity{key=~\"$project_key\"}",
-          "legendFormat": "{{project_key}}",
+          "expr": "sonarqube_complexity{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2196,8 +2196,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_cognitive_complexity{key=~\"$project_key\"}",
-          "legendFormat": "{{project_key}}",
+          "expr": "sonarqube_cognitive_complexity{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2255,8 +2255,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_complexity{key=~\"$project_key\"}",
-          "legendFormat": "{{project_key}}",
+          "expr": "sonarqube_complexity{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2344,8 +2344,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sonarqube_exporter_up{key=~\"$project_key\"}",
-          "legendFormat": "__auto",
+          "expr": "sonarqube_exporter_up{key=~\"$Key\"}",
+          "legendFormat": "{{key}}",
           "range": true,
           "refId": "A"
         }
@@ -2360,7 +2360,7 @@
               "event_id",
               "job",
               "project_version",
-              "project_key"
+              "key"
             ],
             "mode": "columns",
             "valueLabel": "__name__"
@@ -2385,18 +2385,18 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "sonarqube_bugs",
+        "definition": "label_values(sonarqube_ncloc, key)",
         "includeAll": true,
-        "label": "Project Name",
+        "label": "Key",
         "multi": true,
-        "name": "project_name",
+        "name": "Key",
         "options": [],
         "query": {
-          "query": "sonarqube_bugs",
+          "query": "label_values(sonarqube_ncloc, key)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": ".*name=\"([^\"]*).*",
+        "regex": "",
         "type": "query"
       }
     ]


### PR DESCRIPTION
fix(grafana): update PromQL queries, legend formats, and variable templating (#13)

- Replace hardcoded/obsolete project queries with regex matching `key=~"$Key"`.
- Update `$Key` variable query to `label_values(sonarqube_ncloc, key)` with multi-value and all options.
- Set panel legend formats to `{{key}}` to display project identifiers instead of raw metric names.
- Update `README.md` to document Grafana `$Key` variable usage and PromQL filtering.
- Add `paths-ignore` to `.github/workflows/build.yml` to skip CI builds on documentation, workflow, or dashboard asset changes.
